### PR TITLE
Consider Zip entries with file type bits set to 0 as files

### DIFF
--- a/components/shared/lib/src/zip/lazy_zip_decoder.dart
+++ b/components/shared/lib/src/zip/lazy_zip_decoder.dart
@@ -34,8 +34,8 @@ class LazyZipDecoder {
         // UNIX systems has a creator version of 3 decimal at 1 byte offset
         if (zfh.versionMadeBy >> 8 == 3) {
           //final bool isDirectory = file.mode & 0x7000 == 0x4000;
-          final bool isFile = file.mode & 0x3F000 == 0x8000;
-          file.isFile = isFile;
+          final fileType = file.mode & 0xF000;
+          file.isFile = fileType == 0x8000 || fileType == 0x0000;
         } else {
           file.isFile = !file.name.endsWith('/');
         }


### PR DESCRIPTION
The Zip decoder is unable to read /META-INF/container.xml for some ePub files, including Calibre demo file that can be downloaded from https://manual.calibre-ebook.com/conversion.html#epub-advanced-formatting-demo.

The offending code was copied from the archive package https://github.com/brendan-duncan/archive/issues/21, but the archive package has been updated since then to fix the same issue https://github.com/brendan-duncan/archive/pull/234.

This pull request implements the same fix.

P.S.: Thanks for creating this package, it saved me a lot of time!